### PR TITLE
Update prod deploy command

### DIFF
--- a/packages/dev-team-bot/package.json
+++ b/packages/dev-team-bot/package.json
@@ -11,14 +11,14 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "deploy": "yarn run prebuild && yarn run build && yarn run start:prod"
+    "deploy": "yarn && yarn run prebuild && yarn run build && yarn run start:prod"
   },
   "dependencies": {
     "@nestjs/common": "^8.0.0",

--- a/packages/dev-team-bot/package.json
+++ b/packages/dev-team-bot/package.json
@@ -17,8 +17,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json",
-    "deploy": "yarn && yarn run prebuild && yarn run build && yarn run start:prod"
+    "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "^8.0.0",

--- a/packages/dev-team-bot/tsconfig.json
+++ b/packages/dev-team-bot/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2017",
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
# 概要

本番用のデプロイコマンドを Railway の仕様に合わせて変更しました。

## デプロイ失敗ログ

下記のビルドエラーが発生しているので原因を調査します。
メモ：ローカルのビルドでは発生しない状況

```shell
[Installing Node]
[INFO] Getting Node version
Resolving Node version
Downloading and extracting Node v16.14.0
Setting NODE_ENV to production

[Parsing package.json]
[INFO] Parsing package.json
No file to start server
[INFO] either use 'docker run' to start container or add index.js or server.js
Using npm v8.3.1 from Node
Installing node modules

added 742 packages, and audited 743 packages in 51s

82 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
npm notice 
npm notice New minor version of npm available! 8.3.1 -> 8.5.0
npm notice Changelog: <[https://github.com/npm/cli/releases/tag/v8.5.0>](https://github.com/npm/cli/releases/tag/v8.5.0%3E);
npm notice Run `npm install -g npm@8.5.0` to update!
npm notice

> dev-team-bot@1.0.0 prebuild
> rimraf dist

> dev-team-bot@1.0.0 build
> nest build
src/app.controller.ts:8:3 - error TS1241: Unable to resolve signature of method decorator when called as an expression.

8   @Get()
    ~~~~~~
src/app.controller.ts:8:3 - error TS1241: Unable to resolve signature of method decorator when called as an expression.
  Type 'TypedPropertyDescriptor<unknown>' is not assignable to type 'void | TypedPropertyDescriptor<() => string>'.
    Type 'TypedPropertyDescriptor<unknown>' is not assignable to type 'TypedPropertyDescriptor<() => string>'.
      Type 'unknown' is not assignable to type '() => string'.
        Type '{}' provides no match for the signature '(): string'.

8   @Get()
    ~~~~~~
src/ping/ping.controller.ts:8:3 - error TS1241: Unable to resolve signature of method decorator when called as an expression.

8   @Get()
    ~~~~~~
src/ping/ping.controller.ts:8:3 - error TS1241: Unable to resolve signature of method decorator when called as an expression.
  Type 'TypedPropertyDescriptor<unknown>' is not assignable to type 'void | TypedPropertyDescriptor<() => string>'.
    Type 'TypedPropertyDescriptor<unknown>' is not assignable to type 'TypedPropertyDescriptor<() => string>'.
      Type 'unknown' is not assignable to type '() => string'.
        Type '{}' provides no match for the signature '(): string'.

8   @Get()
    ~~~~~~
Found 4 error(s).
ERROR: failed to build: exit status 1
ERROR: failed to build: executing lifecycle: failed with status code: 51
```