### PR TITLE
Add unit tests

### DIFF
--- a/.github/workflows/dev-team-bot.yml
+++ b/.github/workflows/dev-team-bot.yml
@@ -21,6 +21,9 @@ jobs:
     strategy:
       matrix:
         node-version: [16.13.2]
+    env:
+      DISCORD_GUILD_ID: '111222333444555666'
+      DISCORD_DEV_CHANNEL_ALLOWED_LIST: '222333444555666777,333444555666777888'
     defaults:
       run:
         working-directory: ./packages/dev-team-bot

--- a/packages/dev-team-bot/package.json
+++ b/packages/dev-team-bot/package.json
@@ -68,6 +68,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "setupFiles": [
+      "dotenv/config"
+    ]
   }
 }

--- a/packages/dev-team-bot/src/bot/config/botConfig.spec.ts
+++ b/packages/dev-team-bot/src/bot/config/botConfig.spec.ts
@@ -1,0 +1,17 @@
+import botConfig from './botConfig';
+
+describe('botConfig', () => {
+  let config;
+
+  beforeEach(async () => {
+    config = botConfig();
+  });
+
+  it('should be defined guildId', () => {
+    expect(config.guildId).toBeDefined();
+  });
+
+  it('should be defined devAllowedChannelList', () => {
+    expect(config.devAllowedChannelList).toBeDefined();
+  });
+});

--- a/packages/dev-team-bot/src/bot/config/botConfig.spec.ts
+++ b/packages/dev-team-bot/src/bot/config/botConfig.spec.ts
@@ -11,6 +11,10 @@ describe('botConfig', () => {
     expect(config.guildId).toBeDefined();
   });
 
+  it('should be defined guildId that has number strings and 18-digits', () => {
+    expect(config.guildId).toMatch(/[0-9]{18}/);
+  });
+
   it('should be defined devAllowedChannelList', () => {
     expect(config.devAllowedChannelList).toBeDefined();
   });

--- a/packages/dev-team-bot/src/bot/guards/message.guard.spec.ts
+++ b/packages/dev-team-bot/src/bot/guards/message.guard.spec.ts
@@ -1,0 +1,69 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { MessageGuard } from './message.guard';
+
+describe('MessageGuard', () => {
+  let messageGuard;
+  const guildId = '111222333444555666';
+  const firstChannelId = '222333444555666777';
+  const secondChannelId = '333444555666777888';
+
+  beforeEach(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'guildId') {
+                return guildId;
+              }
+
+              if (key === 'devAllowedChannelList') {
+                return [firstChannelId, secondChannelId];
+              }
+
+              return null;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    const configService = moduleRef.get<ConfigService>(ConfigService);
+
+    messageGuard = new MessageGuard(configService);
+  });
+
+  it('should be defined canActive method', () => {
+    expect(messageGuard.canActive).toBeDefined();
+  });
+
+  it('should be returned false when the message author is bot', () => {
+    expect(
+      messageGuard.canActive('messageCreate', [
+        { author: { bot: true }, guildId, channelId: firstChannelId },
+      ]),
+    ).toBe(false);
+  });
+
+  it('should be returned false when the guild ID is different', () => {
+    expect(
+      messageGuard.canActive('messageCreate', [
+        {
+          author: { bot: false },
+          guildId: '000111222333444555',
+          channelId: firstChannelId,
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it('should be returned false when the channel ID is not included dev allowed channel list', () => {
+    expect(
+      messageGuard.canActive('messageCreate', [
+        { author: { bot: false }, guildId, channelId: '999888777666555444' },
+      ]),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
# 概要
#27 を対応

## やったこと
- botConfig.spec.ts を実装
- message.guard.spec.ts を実装
- GitHub Action用環境変数を設定

## 備考
- botConfig.spec.ts
  - `devAllowedChannelList` の個数が不明だったので、一旦定義チェックのみにしています。